### PR TITLE
Fix ereolen login after MitID option has been added

### DIFF
--- a/grawlix/sources/ereolen.py
+++ b/grawlix/sources/ereolen.py
@@ -40,7 +40,7 @@ class Ereolen(Source):
             data = {
                 library_attr_name: library,
                 "agency": libraries[library],
-                "userId": username,
+                "loginBibDkUserId": username,
                 "pincode": password
             },
             follow_redirects = True


### PR DESCRIPTION
After the addition of an option to login with MitID, the name of the library username field has changed.