### PR TITLE
Fix Nextory: bump X-App-Version, null series, missing urllib3 dep

### DIFF
--- a/grawlix/sources/nextory.py
+++ b/grawlix/sources/nextory.py
@@ -30,7 +30,7 @@ class Nextory(Source):
         self._client.headers.update(
             {
                 "X-Application-Id": "200",
-                "X-App-Version": "5.4.1",
+                "X-App-Version": "2026.05.4",
                 "X-Locale": LOCALE,
                 "X-Model": "Personal Computer",
                 "X-Device-Id": device_id,
@@ -139,9 +139,10 @@ class Nextory(Source):
 
     @staticmethod
     def _extract_series_name(product_info: dict) -> Optional[str]:
-        if not "series" in product_info:
+        series = product_info.get("series")
+        if not series:
             return None
-        return product_info["series"]["name"]
+        return series["name"]
 
 
     async def _get_book_id_from_url_id(self, url_id: str) -> str:

--- a/grawlix/sources/saxo.py
+++ b/grawlix/sources/saxo.py
@@ -122,7 +122,7 @@ class Saxo(Source):
         :param url: Url of book
         :returns: Isbn of book
         """
-        isbn_match = re.search(f"\d+$", url)
+        isbn_match = re.search(r"\d+$", url)
         if isbn_match and isbn_match.group():
             return isbn_match.group()
         raise NotImplemented

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pycryptodome",
     "rich",
     "tomli",
+    "urllib3",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

Three small fixes that together make Nextory downloads work again on a fresh install:

- **Nextory `AppDeprecateError`**: bump `X-App-Version` from `5.4.1` to `2026.05.4` (current Android app version). The old value is rejected by `/user/v1/sessions` before login completes.
- **Nextory `TypeError` on standalone books**: `product_info["series"]` can be `None` (not just missing) for books that aren't part of a series. The existing `"series" in product_info` check passed in that case and crashed on the next subscript. Switched to `product_info.get("series")` + truthy check.
- **Missing `urllib3` dependency**: `grawlix/sources/storytel.py` imports `urllib3.util.parse_url` but `urllib3` was only pulled in transitively. Fresh installs (e.g. `uv tool install .`) fail at import time with `ModuleNotFoundError`.

Plus one drive-by:
- `grawlix/sources/saxo.py`: `f"\d+$"` → `r"\d+$"` to silence a `SyntaxWarning` on Python 3.12 (no interpolation in the string, raw form is correct).

## Test plan

- [x] `uv tool install .` succeeds without `--with urllib3`
- [x] `grawlix -u … -p … "https://nextory.com/se/book/husdjur-2041761"` produces `Husdjur.epub`
- [x] `grawlix -u … -p … "https://nextory.com/se/book/lararen-6720576"` produces `Läraren.epub` (this is the standalone-book case that previously crashed in `_extract_series_name`)
- [x] No `SyntaxWarning` from `saxo.py` on import under Python 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)