### PR TITLE
epub: remove stray exit() that aborted downloads after the first book

### DIFF
--- a/grawlix/output/epub.py
+++ b/grawlix/output/epub.py
@@ -135,4 +135,3 @@ class Epub(OutputFormat):
         output.add_item(epub.EpubNcx())
         output.add_item(epub.EpubNav())
         epub.write_epub(location, output)
-        exit()


### PR DESCRIPTION
The `Epub` (EpubInParts) writer called `exit()` immediately after `epub.write_epub(location, output)`, which **terminates the whole process after a single book**. Any multi-book download — a series, or a `-f links.txt` batch — only ever wrote the first ebook, and the async client never got cleaned up.

Removing the `exit()` lets control return normally so `download_book` runs `output_format.close()` and the download loop continues to the next book.

Standalone, critical, and independent of any source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)