### PR TITLE
book: add {author} (primary author) output template field

### DIFF
--- a/grawlix/book.py
+++ b/grawlix/book.py
@@ -25,6 +25,7 @@ class Metadata:
             "identifier": self.identifier or "UNKNOWN",
             "language": self.language or "UNKNOWN",
             "authors": "; ".join(self.authors),
+            "author": self.authors[0] if self.authors else "UNKNOWN",
             "description": self.description or "UNKNOWN",
             "release_date": self.release_date.isoformat() if self.release_date else "UNKNOWN",
         }


### PR DESCRIPTION
`Metadata.as_dict()` only exposed `{authors}` (all authors joined with `; `), which scatters a single author across multiple folders when books credit co-authors/illustrators (e.g. `J.K. Rowling; Newt Scamander`).

Adds an `{author}` field (the first author, or `UNKNOWN` if none) so users can organize by primary author:
```
grawlix -o "{author}/{title}.{ext}" <url>
```
Purely additive — existing templates are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)